### PR TITLE
Enable multi-season GDA comparison

### DIFF
--- a/frontend/src/app/features/zonas/zona-view/zona-view.component.html
+++ b/frontend/src/app/features/zonas/zona-view/zona-view.component.html
@@ -200,6 +200,19 @@
       <button class="btn btn-outline-success mb-3" (click)="descargarGrafico()">
         Descargar Gráfico
       </button>
+      <div class="mb-3" *ngIf="temporadas.length > 0">
+        <label class="form-label">Comparar temporadas</label>
+        <select
+          class="form-select"
+          multiple
+          [(ngModel)]="temporadasCompararIds"
+          (change)="actualizarGraficoGradosDia()"
+        >
+          <option *ngFor="let temp of temporadas" [ngValue]="temp.id">
+            {{ temp.nombre }}
+          </option>
+        </select>
+      </div>
       <canvas
         #graficoCanvas
         baseChart


### PR DESCRIPTION
## Summary
- allow selecting several seasons for the GDA chart
- compute datasets per selected season and assign colors
- add UI to choose seasons for comparison

## Testing
- `npx tsc -p tsconfig.app.json`
- `npm test` *(fails: tsconfig.spec.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68406778e1fc8333a2472b4064ff7680