### PR TITLE
Add modals for bulk deletion

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -668,8 +668,8 @@ app.get("/zonas/:zonaId/eto-consumo-dia", (req, res) => {
   });
 });
 
-// Registrar eto y consumos diarios de una zona
-app.post("/zonas/:zonaId/eto-consumo-dia", (req, res) => {
+  // Registrar eto y consumos diarios de una zona
+  app.post("/zonas/:zonaId/eto-consumo-dia", (req, res) => {
   const { zonaId } = req.params;
   const {
     fecha,
@@ -732,6 +732,24 @@ app.post("/zonas/:zonaId/eto-consumo-dia", (req, res) => {
         });
       }
     );
+  });
+
+  // Eliminar registro de ETo diario
+  app.delete("/zonas/:zonaId/eto-consumo-dia/:id", (req, res) => {
+    const { zonaId, id } = req.params;
+    const sql =
+      "DELETE FROM eto_consumo_dia WHERE id_eto_dia = ? AND id_zona = ?";
+
+    db.query(sql, [id, zonaId], (err) => {
+      if (err) {
+        console.error("❌ Error al eliminar eto_consumo_dia:", err);
+        return res
+          .status(500)
+          .json({ error: "Error al eliminar eto_consumo_dia" });
+      }
+
+      res.json({ message: "ETo diario eliminado correctamente" });
+    });
   });
 });
 
@@ -844,6 +862,21 @@ app.post("/zonas/:id/clima-semanal", (req, res) => {
         });
       }
     );
+  });
+});
+
+// Eliminar clima semanal por ID
+app.delete("/zonas/:zonaId/clima-semanal/:climaId", (req, res) => {
+  const { zonaId, climaId } = req.params;
+  const sql = "DELETE FROM clima_dia WHERE id = ? AND id_zona = ?";
+
+  db.query(sql, [climaId, zonaId], (err) => {
+    if (err) {
+      console.error("❌ Error al eliminar clima:", err);
+      return res.status(500).json({ error: "Error al eliminar clima" });
+    }
+
+    res.json({ message: "Clima eliminado correctamente" });
   });
 });
 

--- a/frontend/src/app/core/services/zonas.service.ts
+++ b/frontend/src/app/core/services/zonas.service.ts
@@ -47,6 +47,10 @@ export class ZonasService {
     return this.http.post(`${this.apiUrl}/${zonaId}/clima-semanal`, datos);
   }
 
+  eliminarClima(zonaId: number, id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/${zonaId}/clima-semanal/${id}`);
+  }
+
   getEtoConsumoDia(zonaId: number): Observable<EtoConsumoDia[]> {
     return this.http.get<EtoConsumoDia[]>(
       `${this.apiUrl}/${zonaId}/eto-consumo-dia`
@@ -55,5 +59,9 @@ export class ZonasService {
 
   guardarEtoConsumoDia(zonaId: number, datos: EtoConsumoDia): Observable<any> {
     return this.http.post(`${this.apiUrl}/${zonaId}/eto-consumo-dia`, datos);
+  }
+
+  eliminarEtoConsumoDia(zonaId: number, id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/${zonaId}/eto-consumo-dia/${id}`);
   }
 }

--- a/frontend/src/app/features/zonas/zona-view/zona-view.component.html
+++ b/frontend/src/app/features/zonas/zona-view/zona-view.component.html
@@ -57,6 +57,12 @@
         <button class="btn btn-outline-primary" (click)="abrirModalManual()">
           Agregar Manualmente
         </button>
+        <button
+          class="btn btn-outline-danger ms-2"
+          (click)="abrirModalEliminarConsumo()"
+        >
+          Eliminar Registros
+        </button>
       </div>
 
       <!-- 📊 Tabla de Consumo -->
@@ -109,10 +115,9 @@
             </tr>
           </tbody>
         </table>
-      </div>
-    </div>
-  </div>
-
+                </div>
+              </div>
+            </div>
   <!-- 🌦️ Sección: Información Climática -->
   <div class="card shadow-sm border-dark mb-4">
     <div
@@ -150,6 +155,12 @@
           (click)="abrirModalClimaManual()"
         >
           Agregar Clima Manual
+        </button>
+        <button
+          class="btn btn-outline-danger ms-2"
+          (click)="abrirModalEliminarClima()"
+        >
+          Eliminar Registros
         </button>
       </div>
 
@@ -237,6 +248,12 @@
         </button>
         <button class="btn btn-outline-primary" (click)="abrirModalEtoManual()">
           Agregar ETo Manual
+        </button>
+        <button
+          class="btn btn-outline-danger ms-2"
+          (click)="abrirModalEliminarEto()"
+        >
+          Eliminar Registros
         </button>
       </div>
       <div class="card-body text-end">
@@ -636,6 +653,189 @@
         </button>
         <button class="btn btn-primary" (click)="guardarRecomendacion()">
           Guardar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Eliminar ETo Diario -->
+<div
+  class="modal fade"
+  id="modalEliminarEto"
+  tabindex="-1"
+  aria-hidden="true"
+  [ngClass]="{ 'show d-block': mostrarModalEliminarEto }"
+>
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-white">
+        <h5 class="modal-title">Eliminar ETo Diario</h5>
+        <button
+          type="button"
+          class="btn-close"
+          (click)="mostrarModalEliminarEto = false"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <input
+          type="text"
+          class="form-control mb-2"
+          placeholder="Buscar..."
+          [(ngModel)]="filtroEto"
+        />
+        <div class="tabla-scroll">
+          <table class="table table-sm table-bordered text-center">
+            <thead class="table-secondary">
+              <tr>
+                <th></th>
+                <th>Fecha</th>
+                <th>ETo</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let e of etoBusqueda">
+                <td>
+                  <input
+                    type="checkbox"
+                    (change)="onCheckChange(e.id_eto_dia!, $event.target.checked, 'eto')"
+                  />
+                </td>
+                <td>{{ e.fecha | date : 'dd-MM-yyyy' }}</td>
+                <td>{{ e.eto }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" (click)="mostrarModalEliminarEto = false">Cancelar</button>
+        <button class="btn btn-danger" (click)="confirmarEliminarEto()">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Eliminar Clima -->
+<div
+  class="modal fade"
+  id="modalEliminarClima"
+  tabindex="-1"
+  aria-hidden="true"
+  [ngClass]="{ 'show d-block': mostrarModalEliminarClima }"
+>
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-white">
+        <h5 class="modal-title">Eliminar Información Climática</h5>
+        <button
+          type="button"
+          class="btn-close"
+          (click)="mostrarModalEliminarClima = false"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <input
+          type="text"
+          class="form-control mb-2"
+          placeholder="Buscar..."
+          [(ngModel)]="filtroClima"
+        />
+        <div class="tabla-scroll">
+          <table class="table table-sm table-bordered text-center">
+            <thead class="table-secondary">
+              <tr>
+                <th></th>
+                <th>Fecha</th>
+                <th>Min</th>
+                <th>Max</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let d of climaBusqueda">
+                <td>
+                  <input
+                    type="checkbox"
+                    (change)="onCheckChange(d.id!, $event.target.checked, 'clima')"
+                  />
+                </td>
+                <td>{{ d.fecha | date : 'dd-MM-yyyy' }}</td>
+                <td>{{ d.ta_min }}</td>
+                <td>{{ d.ta_max }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" (click)="mostrarModalEliminarClima = false">Cancelar</button>
+        <button class="btn btn-danger" (click)="confirmarEliminarClima()">Eliminar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal Eliminar Consumo -->
+<div
+  class="modal fade"
+  id="modalEliminarConsumo"
+  tabindex="-1"
+  aria-hidden="true"
+  [ngClass]="{ 'show d-block': mostrarModalEliminarConsumo }"
+>
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-white">
+        <h5 class="modal-title">Eliminar Consumo de Agua</h5>
+        <button
+          type="button"
+          class="btn-close"
+          (click)="mostrarModalEliminarConsumo = false"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <input
+          type="text"
+          class="form-control mb-2"
+          placeholder="Buscar..."
+          [(ngModel)]="filtroConsumo"
+        />
+        <div class="tabla-scroll">
+          <table class="table table-sm table-bordered text-center">
+            <thead class="table-secondary">
+              <tr>
+                <th></th>
+                <th>Semana</th>
+                <th>ETo</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let c of consumoBusqueda">
+                <td>
+                  <input
+                    type="checkbox"
+                    (change)="onCheckChange(c.id!, $event.target.checked, 'consumo')"
+                  />
+                </td>
+                <td>
+                  {{ c.semana_inicio | date : 'dd-MM-yyyy' }} a
+                  {{ c.semana_fin | date : 'dd-MM-yyyy' }}
+                </td>
+                <td>{{ c.eto }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button
+          class="btn btn-secondary"
+          (click)="mostrarModalEliminarConsumo = false"
+        >
+          Cancelar
+        </button>
+        <button class="btn btn-danger" (click)="confirmarEliminarConsumo()">
+          Eliminar
         </button>
       </div>
     </div>

--- a/frontend/src/app/features/zonas/zona-view/zona-view.component.ts
+++ b/frontend/src/app/features/zonas/zona-view/zona-view.component.ts
@@ -21,6 +21,7 @@ import * as XLSX from 'xlsx';
 import * as FileSaver from 'file-saver';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import { CrawlerService } from '../../../core/services/crawler.service';
+import { firstValueFrom } from 'rxjs';
 
 declare var bootstrap: any;
 
@@ -121,6 +122,17 @@ export class ZonaViewComponent implements OnInit {
     consumo_carrete?: number;
     consumo_aspersor?: number;
   }[] = [{ fecha: '', eto: 0, kc: 1 }];
+
+  // Eliminación masiva
+  mostrarModalEliminarConsumo = false;
+  mostrarModalEliminarClima = false;
+  mostrarModalEliminarEto = false;
+  filtroConsumo = '';
+  filtroClima = '';
+  filtroEto = '';
+  consumoSeleccionadosIds: number[] = [];
+  climaSeleccionadosIds: number[] = [];
+  etoSeleccionadosIds: number[] = [];
 
   constructor(
     private route: ActivatedRoute,
@@ -1116,5 +1128,122 @@ export class ZonaViewComponent implements OnInit {
       labels.push(`${month}-${day}`);
     }
     return labels;
+  }
+
+  abrirModalEliminarConsumo(): void {
+    this.consumoSeleccionadosIds = [];
+    this.filtroConsumo = '';
+    this.mostrarModalEliminarConsumo = true;
+  }
+
+  abrirModalEliminarClima(): void {
+    this.climaSeleccionadosIds = [];
+    this.filtroClima = '';
+    this.mostrarModalEliminarClima = true;
+  }
+
+  abrirModalEliminarEto(): void {
+    this.etoSeleccionadosIds = [];
+    this.filtroEto = '';
+    this.mostrarModalEliminarEto = true;
+  }
+
+  get consumoBusqueda(): ConsumoAgua[] {
+    const term = this.filtroConsumo.toLowerCase();
+    return this.consumoAgua.filter(
+      (c) =>
+        c.semana_inicio.includes(term) ||
+        c.semana_fin.includes(term)
+    );
+  }
+
+  get climaBusqueda(): ClimaZona[] {
+    const term = this.filtroClima.toLowerCase();
+    return this.climaZona.filter((c) => c.fecha.includes(term));
+  }
+
+  get etoBusqueda(): EtoConsumoDia[] {
+    const term = this.filtroEto.toLowerCase();
+    return this.etoConsumoDia.filter((e) => e.fecha.includes(term));
+  }
+
+  confirmarEliminarConsumo(): void {
+    if (this.consumoSeleccionadosIds.length === 0) return;
+    Swal.fire({
+      title: '¿Eliminar registros seleccionados?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, eliminar',
+    }).then((r) => {
+      if (r.isConfirmed) {
+        const peticiones = this.consumoSeleccionadosIds.map((id) =>
+          firstValueFrom(this.aguaService.eliminarConsumoAgua(id, this.zona.id))
+        );
+        Promise.all(peticiones).then(() => {
+          this.toastr.success('Registros eliminados');
+          this.obtenerConsumoAgua();
+          this.mostrarModalEliminarConsumo = false;
+        });
+      }
+    });
+  }
+
+  confirmarEliminarClima(): void {
+    if (this.climaSeleccionadosIds.length === 0) return;
+    Swal.fire({
+      title: '¿Eliminar registros seleccionados?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, eliminar',
+    }).then((r) => {
+      if (r.isConfirmed) {
+        const peticiones = this.climaSeleccionadosIds.map((id) =>
+          firstValueFrom(this.zonasService.eliminarClima(this.zona.id, id))
+        );
+        Promise.all(peticiones).then(() => {
+          this.toastr.success('Registros eliminados');
+          this.obtenerClima();
+          this.mostrarModalEliminarClima = false;
+        });
+      }
+    });
+  }
+
+  confirmarEliminarEto(): void {
+    if (this.etoSeleccionadosIds.length === 0) return;
+    Swal.fire({
+      title: '¿Eliminar registros seleccionados?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, eliminar',
+    }).then((r) => {
+      if (r.isConfirmed) {
+        const peticiones = this.etoSeleccionadosIds.map((id) =>
+          firstValueFrom(
+            this.zonasService.eliminarEtoConsumoDia(this.zona.id, id)
+          )
+        );
+        Promise.all(peticiones).then(() => {
+          this.toastr.success('Registros eliminados');
+          this.obtenerEtoConsumoDia();
+          this.mostrarModalEliminarEto = false;
+        });
+      }
+    });
+  }
+
+  onCheckChange(id: number, checked: boolean, tipo: string): void {
+    const lista =
+      tipo === 'consumo'
+        ? this.consumoSeleccionadosIds
+        : tipo === 'clima'
+        ? this.climaSeleccionadosIds
+        : this.etoSeleccionadosIds;
+    if (checked) {
+      if (!lista.includes(id)) lista.push(id);
+    } else {
+      const idx = lista.indexOf(id);
+      if (idx > -1) lista.splice(idx, 1);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- support deleting eto daily and climate entries via API
- expose deletion methods in `ZonasService`
- implement bulk deletion modals for Consumo de Agua, Información Climática and Eto diario
- hook up new buttons in zone view

## Testing
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm run test` *(fails: tsconfig.spec.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846ff81f3948333bbd06d52eba0056c