### PR TITLE
Add dark mode toggle

### DIFF
--- a/frontend/src/app/shared/navbar/navbar.component.html
+++ b/frontend/src/app/shared/navbar/navbar.component.html
@@ -12,7 +12,7 @@
       />
     </a>
 
-    <!-- 🟣 Zona derecha: Botón de conceptos + botón menú -->
+    <!-- 🟣 Zona derecha: Botón de conceptos + botón de tema + botón menú -->
     <div class="d-flex align-items-center">
       <!-- 📘 Botón de Conceptos -->
       <button
@@ -20,6 +20,14 @@
         routerLink="/conceptos"
       >
         Conceptos de Riego
+      </button>
+
+      <!-- 🌗 Botón Modo oscuro/claro -->
+      <button
+        class="btn btn-outline-light me-2"
+        (click)="toggleDarkMode()"
+      >
+        {{ darkMode ? '☀️' : '🌙' }}
       </button>
 
       <!-- ☰ Botón de menú (solo visible en móviles) -->

--- a/frontend/src/app/shared/navbar/navbar.component.ts
+++ b/frontend/src/app/shared/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { AuthService } from '../../core/services/auth.service';
@@ -13,8 +13,9 @@ declare var bootstrap: any;
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
-export class NavbarComponent {
+export class NavbarComponent implements OnInit {
   menuOpen = false;
+  darkMode = false;
 
   loginData = {
     correo: '',
@@ -27,8 +28,25 @@ export class NavbarComponent {
     private toastr: ToastrService
   ) {}
 
+  ngOnInit(): void {
+    this.darkMode = localStorage.getItem('darkMode') === 'true';
+    if (this.darkMode) {
+      document.body.classList.add('dark-mode');
+    }
+  }
+
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
+  }
+
+  toggleDarkMode(): void {
+    this.darkMode = !this.darkMode;
+    if (this.darkMode) {
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+    }
+    localStorage.setItem('darkMode', this.darkMode.toString());
   }
 
   cerrarSesion(): void {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -9,3 +9,27 @@ body {
   z-index: 9999 !important;
   position: fixed !important;
 }
+
+body.dark-mode {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+
+body.dark-mode .navbar {
+  background-color: #212529 !important;
+}
+
+body.dark-mode .nav-menu {
+  background-color: rgba(0, 0, 0, 0.95);
+}
+
+body.dark-mode .top-section {
+  background: rgba(0, 0, 0, 0.6);
+  color: #f8f9fa;
+}
+
+body.dark-mode .region-link {
+  border-color: #f8f9fa;
+  color: #f8f9fa;
+  background: rgba(33, 37, 41, 0.9);
+}


### PR DESCRIPTION
## Summary
- add dark mode styles
- implement dark mode toggle in navbar

## Testing
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm run test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684ac08f65a88333a9eea970cc918fc8