### PR TITLE
Add Cloud SQL connection docs

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -74,6 +74,18 @@ CMD ["node", "server.js"]
 - Usa variables de entorno definidas en el entorno de ejecución.
 - Se construye y despliega desde `cloudbuild.yaml`.
 
+### Conectar Cloud Run a Cloud SQL
+
+Habilita la conexión con tu instancia de Cloud SQL desde la configuración del
+servicio en la consola de Cloud Run o con el comando:
+
+```bash
+gcloud run deploy --add-cloudsql-instances=INSTANCIA
+```
+
+De lo contrario el directorio `/cloudsql/...` no estará disponible en el
+contenedor y la aplicación terminará antes de comenzar a escuchar.
+
 ---
 
 ¿Preguntas sobre el backend? Puedes revisarlo en `server.js` y `crawlerINIA.js`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -79,6 +79,20 @@ on:
 - El contenedor debe escuchar en el puerto especificado por la variable `PORT` (por defecto 8080).
 - Las variables de entorno del backend se configuran directamente en la consola de Cloud Run.
 
+## 🔗 Conectar Cloud Run a Cloud SQL
+
+Para que el backend se comunique con la base de datos es necesario habilitar
+la conexión de **Cloud SQL** en el servicio de Cloud Run. Esto puede hacerse en
+la consola marcando la opción correspondiente o ejecutando:
+
+```bash
+gcloud run deploy --add-cloudsql-instances=INSTANCIA
+```
+
+Sin esta configuración no se creará el directorio de sockets
+`/cloudsql/...` dentro del contenedor y la aplicación se cerrará antes de
+escuchar peticiones.
+
 ---
 
 ## 🧪 Pruebas Automatizadas


### PR DESCRIPTION
## Summary
- document how to enable Cloud SQL sockets in Cloud Run
- note consequences if the Cloud SQL connection is not configured

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68540a8837b483339facf3044dfed58d